### PR TITLE
Fix node-ts load config

### DIFF
--- a/lib/patch.js
+++ b/lib/patch.js
@@ -1,6 +1,6 @@
 const Module = require('module');
 const path = require('path');
-require('ts-node').register({ project: __dirname + '/../ts-node-config' });
+require('ts-node').register({ project: __dirname + '/../ts-node-config/tsconfig.json' });
 
 function requireTransformer(dir, module) {
     const m = new Module();


### PR DESCRIPTION
Ts-node 5.0.0 now uses the default typescript config loader (see https://github.com/TypeStrong/ts-node/commit/7164ab734c73167dce9adc2538e98d3d9999f7f6), which requires explicitly specifying `tsconfig.json` file.