### PR TITLE
fix: spell error for `transform`.

### DIFF
--- a/src/patchCreateProgram.ts
+++ b/src/patchCreateProgram.ts
@@ -77,8 +77,8 @@ function preparePluginsFromCompilerOptions(plugins: any): PluginConfig[] {
     if (plugins.length === 1 && plugins[0].customTransformers) {
         const { before = [], after = [] } = plugins[0].customTransformers;
         return [
-            ...before.map((item: string) => ({ tranform: item, before: true })),
-            ...after.map((item: string) => ({ tranform: item, after: true })),
+            ...before.map((item: string) => ({ transform: item, before: true })),
+            ...after.map((item: string) => ({ transform: item, after: true })),
         ];
     }
     return plugins;


### PR DESCRIPTION
fix: spell error for `transform`, it will lead to config verify fail. 
https://github.com/cevek/ttypescript/blob/2ae1041b4c3bedf6dbc73adbc0612bc7ec33bb22/src/PluginCreator.ts#L208