### PR TITLE
Expose modified TypeScript object

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,12 @@ export default function (program: ts.Program, pluginOptions: {}) {
 }
 ```
 
+If your transform needs to patch the `typescript` module, you can get access to it like this:
+```ts
+import tsModule from 'ttypescript/lib/tsmodule';
+tsModule.tsModule.nodeCanBeDecorated = () => true;
+```
+
 Examples of transformers
 
 [`{transform: "ts-transformer-keys/transformer"}`](https://github.com/kimamula/ts-transformer-keys) 

--- a/packages/ttypescript/src/tsc.ts
+++ b/packages/ttypescript/src/tsc.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as resolve from 'resolve';
 import * as vm from 'vm';
 import { patchCreateProgram } from './patchCreateProgram';
+import tsModule from './tsmodule';
 
 const opts = { basedir: process.cwd() };
 
@@ -31,5 +32,6 @@ const context = vm.createContext({
 
 const tss = script.runInContext(context);
 patchCreateProgram(tss, true);
+tsModule.tsModule = tss;
 
 tss.executeCommandLine(tss.sys.args);

--- a/packages/ttypescript/src/tsmodule.ts
+++ b/packages/ttypescript/src/tsmodule.ts
@@ -1,0 +1,3 @@
+import * as ts from 'typescript';
+const defaultExport: { tsModule: any } = { tsModule: ts };
+export default defaultExport;


### PR DESCRIPTION
Some plugins may want to patch the TypeScript object in order to provide, for instance, the ability to allow decorators on any node.
Because the TypeScript module that will be acquired with `import * from 'ts'` will be a separate module instance, this will no longer allow modification of the currently active ts library.

This is overcome by exporting the patched ts module instance from where it can be imported by plugin modules that support this.