### PR TITLE
Allow customer transformers alongside plugins' ones

### DIFF
--- a/packages/ttypescript/__tests__/typescript.spec.ts
+++ b/packages/ttypescript/__tests__/typescript.spec.ts
@@ -51,6 +51,34 @@ console.log(abc.toString());
         expect(res.outputText).toEqual(result);
     });
 
+    it('should merge transformers', () => {
+        const content = fs.readFileSync(path.join(exampleDir, 'test.ts')).toString();
+        const customTransformer = jest.fn(sf => sf)
+
+        const res = ts.transpileModule(content, {
+            compilerOptions: {
+                plugins: [
+                    {
+                        transform: __dirname + '/transforms/safely.ts',
+                    },
+                ] as any,
+            },
+            transformers: {
+                before: [() => customTransformer]
+            },
+        });
+
+        const result = `var a = { b: 1 };
+function abc() {
+    var c = a && a.b;
+}
+console.log(abc.toString());
+`;
+
+        expect(res.outputText).toEqual(result);
+        expect(customTransformer).toHaveBeenCalled()
+    });
+
     it('should run 3rd party transformers', () => {
         const res = ts.transpileModule('var x = 1;', {
             compilerOptions: {

--- a/packages/ttypescript/src/PluginCreator.ts
+++ b/packages/ttypescript/src/PluginCreator.ts
@@ -33,6 +33,7 @@ export interface TransformerBasePlugin {
     after?: ts.TransformerFactory<ts.SourceFile>;
     afterDeclarations?: ts.TransformerFactory<ts.SourceFile | ts.Bundle>;
 }
+export type TransformerList = Required<ts.CustomTransformers>
 
 export type TransformerPlugin = TransformerBasePlugin | ts.TransformerFactory<ts.SourceFile>;
 
@@ -124,29 +125,22 @@ export class PluginCreator {
         this.validateConfigs(configs);
     }
 
-    mergeTransformers(into: ts.CustomTransformers, source: ts.CustomTransformers | TransformerBasePlugin) {
+    mergeTransformers(into: TransformerList, source: ts.CustomTransformers | TransformerBasePlugin) {
         const slice = <T>(input: T | T[]) => Array.isArray(input) ? input.slice() : [input]
         if (source.before) {
-            if (into.before) into.before.push(...slice(source.before));
-            else into.before = slice(source.before);
+            into.before.push(...slice(source.before));
         }
         if (source.after) {
-            if (into.after) into.after.push(...slice(source.after));
-            else into.after = slice(source.after);
+            into.after.push(...slice(source.after));
         }
         if (source.afterDeclarations) {
-            if (into.afterDeclarations) into.afterDeclarations.push(...slice(source.afterDeclarations));
-            else into.afterDeclarations = slice(source.afterDeclarations);
+            into.afterDeclarations.push(...slice(source.afterDeclarations));
         }
         return this
     }
 
     createTransformers(params: { program: ts.Program } | { ls: ts.LanguageService }, customTransformers?: ts.CustomTransformers) {
-        const chain: {
-            before: ts.TransformerFactory<ts.SourceFile>[];
-            after: ts.TransformerFactory<ts.SourceFile>[];
-            afterDeclarations: ts.TransformerFactory<ts.SourceFile | ts.Bundle>[];
-        } = {
+        const chain: TransformerList = {
             before: [],
             after: [],
             afterDeclarations: [],

--- a/packages/ttypescript/src/patchCreateProgram.ts
+++ b/packages/ttypescript/src/patchCreateProgram.ts
@@ -74,9 +74,10 @@ export function patchCreateProgram(tsm: typeof ts, forceReadConfig = false, proj
             writeFile?: ts.WriteFileCallback,
             cancellationToken?: ts.CancellationToken,
             emitOnlyDtsFiles?: boolean,
-            customTransformers: ts.CustomTransformers = pluginCreator.createTransformers({ program })
+            customTransformers?: ts.CustomTransformers
         ): ts.EmitResult {
-            return originEmit(targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers);
+            const mergedTransformers = pluginCreator.createTransformers({ program }, customTransformers)
+            return originEmit(targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, mergedTransformers);
         };
 
         return program;


### PR DESCRIPTION
If custom transformers were given as arguments, it would discard the ones from any plugin. This merges transformers, appending the ones given as arguments.

Closes #25