### PR TITLE
replace eval with vm.runInThisContext

### DIFF
--- a/packages/ttypescript/src/loadTypescript.ts
+++ b/packages/ttypescript/src/loadTypescript.ts
@@ -12,11 +12,13 @@ export function loadTypeScript(
     const opts = { basedir: folder };
     const typescriptFilename = resolve.sync('typescript/lib/' + filename, opts);
 
+    const module = { exports: ts }
     const code = fs.readFileSync(typescriptFilename, 'utf8');
     runInThisContext(
         `(function (exports, require, module, __filename, __dirname, ts) {${code}\n});`,
         { filename: typescriptFilename, lineOffset: 0, displayErrors: true }
-    ).call(ts, ts, require, { exports: ts }, typescriptFilename, dirname(typescriptFilename), ts);
+    ).call(ts, ts, require, module, typescriptFilename, dirname(typescriptFilename), ts);
+    ts = module.exports
 
     const [major, minor] = ts.versionMajorMinor.split('.');
     if (+major < 3 && +minor < 7) {

--- a/packages/ttypescript/src/loadTypescript.ts
+++ b/packages/ttypescript/src/loadTypescript.ts
@@ -3,20 +3,21 @@ import * as resolve from 'resolve';
 import * as TS from 'typescript';
 import { patchCreateProgram } from './patchCreateProgram';
 import { dirname } from 'path';
+import { runInThisContext } from 'vm'
 
 export function loadTypeScript(
     filename: string,
-    { folder = __dirname, forceConfigLoad = false }: { folder?: string; forceConfigLoad?: boolean } = {}
+    { folder = __dirname, forceConfigLoad = false, ts = {} as any }: { folder?: string; forceConfigLoad?: boolean, ts?: typeof TS } = {}
 ): typeof TS {
     const opts = { basedir: folder };
     const typescriptFilename = resolve.sync('typescript/lib/' + filename, opts);
 
     const code = fs.readFileSync(typescriptFilename, 'utf8');
-    const module = { exports: {} as typeof TS };
-    __filename = typescriptFilename;
-    __dirname = dirname(__filename);
-    eval(code);
-    const ts = module.exports;
+    runInThisContext(
+        `(function (exports, require, module, __filename, __dirname, ts) {${code}\n});`,
+        { filename: typescriptFilename, lineOffset: 0, displayErrors: true }
+    ).call(ts, ts, require, { exports: ts }, typescriptFilename, dirname(typescriptFilename), ts);
+
     const [major, minor] = ts.versionMajorMinor.split('.');
     if (+major < 3 && +minor < 7) {
         throw new Error('ttypescript supports typescript from 2.7 version');

--- a/packages/ttypescript/src/tsc.ts
+++ b/packages/ttypescript/src/tsc.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as resolve from 'resolve';
 import { loadTypeScript } from './loadTypescript';
 import { dirname } from 'path';
+import { runInThisContext } from 'vm'
 
 const ts = loadTypeScript('typescript', { folder: process.cwd(), forceConfigLoad: true });
 const tscFileName = resolve.sync('typescript/lib/tsc', { basedir: process.cwd() });
@@ -10,7 +11,9 @@ const commandLineTsCode = fs
     .replace(/^[\s\S]+(\(function \(ts\) \{\s+function countLines[\s\S]+)$/, '$1')
     .replace('ts.executeCommandLine(ts.sys.args);', '');
 
-__filename = tscFileName;
-__dirname = dirname(__filename);
-eval(commandLineTsCode);
+runInThisContext(
+    `(function (exports, require, module, __filename, __dirname, ts) {${commandLineTsCode}\n});`,
+    { filename: tscFileName, lineOffset: 0, displayErrors: true }
+).call(ts, ts, require, { exports: ts }, tscFileName, dirname(tscFileName), ts);
+
 (ts as any).executeCommandLine(ts.sys.args);


### PR DESCRIPTION
Instead of using "eval", NodeJS exposes [vm.runInThisContext](https://nodejs.org/api/vm.html#vm_vm_runinthiscontext_code_options) that is internally used by commonjs require().
The code executed with `vm.runInThisContext` has the correct stack trace when an exception is thrown and may be better optimised by V8 engine. See [node loader.js function _compile()](https://github.com/nodejs/node/blob/903630e72ece60c764b9cac9d0941400377b7ac6/lib/internal/modules/cjs/loader.js#L681)

In this PR, `eval()` is replaced with `vm.runInThisContext` and a new optional field `ts?: typeof TS` is added to the options argument of loadTypeScript.