### PR TITLE
move ts-node from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lerna": "^3.8.1",
     "ts-jest": "^23.10.5",
     "ts-nameof": "^2.0.0",
-    "ts-node": "^7.0.1",
+    "ts-node": "^8.0.2",
     "ts-transform-css-modules": "^0.3.3",
     "ts-transform-graphql-tag": "^0.2.1",
     "ts-transform-img": "^0.3.2",

--- a/packages/ttypescript/__tests__/tsnode.spec.ts
+++ b/packages/ttypescript/__tests__/tsnode.spec.ts
@@ -3,7 +3,7 @@ import { configs } from './configs';
 
 describe('ts-node', () => {
     it('should transform', () => {
-        const result = execSync('node ' + configs.tsNodePath + ' --no-cache -C ' + configs.typescriptFromLibPath + ' tsnode.ts', {
+        const result = execSync('node ' + configs.tsNodePath + ' -C ' + configs.typescriptFromLibPath + ' tsnode.ts', {
             cwd: __dirname + '/assets/',
             maxBuffer: 1e8,
         });

--- a/packages/ttypescript/package.json
+++ b/packages/ttypescript/package.json
@@ -32,6 +32,7 @@
     "resolve": "^1.9.0"
   },
   "peerDependencies": {
-    "ts-node": "^8.0.2"
+    "ts-node": "^8.0.2",
+    "typescript": "^3.2.2"
   }
 }

--- a/packages/ttypescript/package.json
+++ b/packages/ttypescript/package.json
@@ -29,7 +29,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "resolve": "^1.9.0",
-    "ts-node": "^7.0.1"
+    "resolve": "^1.9.0"
+  },
+  "peerDependencies": {
+    "ts-node": "^8.0.2"
   }
 }


### PR DESCRIPTION
I think `ts-node` should be [peerDependencies](https://nodejs.org/en/blog/npm/peer-dependencies/), instead of dependences, as well as typescript itself.



P.S. Thanks for this module, which is just what I want.

