### PR TITLE
Middleware support to allow arbitrary `ts.CompilerHost` changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ export interface PluginConfig {
     /**
      * Plugin entry point format type, default is program
      */
-    type?: 'program' | 'config' | 'checker' | 'raw' | 'compilerOptions';
+    type?: 'program' | 'config' | 'checker' | 'raw' | 'compilerOptions' | 'middleware';
 
     /**
      * Should transformer applied after all ones
@@ -151,6 +151,45 @@ Plugin config entry: `{ "transform": "transformer-module", type: "compilerOption
             { "transform": "transformer-module", "after": true },
             { "transform": "transformer-module", "afterDeclarations": true },
             { "transform": "transformer-module", "type": "ls" }
+        ]
+    },
+}
+```
+#### middleware
+This type is special — it allows to intercept the build process before it starts, by hooking into `ts.createProgram`, in style similar to Express middlewares.
+
+This mechanism allows to implement virtual modules, virtual file system, custom loaders etc.
+
+Example middleware:
+
+```ts
+import * as ts from 'typescript';
+
+export default function(config: { foo: string, bar?: string }): ts.Middleware {
+    return {
+        createProgram(opts, next) {
+            // somehow change options - for example, intercept methods of CompilerHost
+            opts.host = opts.host ? opts.host : ts.createCompilerHost(opts.options);
+
+            // pass control either to real ts.createProgram, or to the earlier middleware
+            const program = next(opts);
+
+            // do something with built program
+            console.log(program.getTypeCount());
+
+            return program;
+        }
+    }
+}
+```
+
+Example configuration:
+
+```json
+{
+    "compilerOptions": {
+        "plugins": [
+            { "transform": "some-middleware-module", foo: "this is config property", bar: "this is too" }
         ]
     },
 }

--- a/packages/ttypescript/__tests__/middlewares/create-program.ts
+++ b/packages/ttypescript/__tests__/middlewares/create-program.ts
@@ -1,0 +1,47 @@
+import * as ts from 'typescript'
+
+interface TestConfig {
+    trace: (message: string) => void;
+}
+
+export function foo(config: TestConfig): ts.Middleware {
+    return {
+        createProgram(opts, next) {
+            config.trace("foo: before");
+
+            opts.host = opts.host ? opts.host : ts.createCompilerHost(opts.options);
+            const host = opts.host;
+
+            const originFileExists = host.fileExists.bind(host);
+
+            let existsCalled = false;
+            host.fileExists = (fileName: string): boolean => {
+                if (!existsCalled) {
+                    existsCalled = true;
+                    config.trace("in hook");
+                }
+                return originFileExists(fileName);
+            }
+
+            const result = next(opts);
+
+            config.trace("foo: after");
+
+            return result;
+        }
+    }
+}
+
+export function bar(config: TestConfig): ts.Middleware {
+    return {
+        createProgram(opts, next) {
+            config.trace("bar: before");
+
+            const result = next(opts);
+
+            config.trace("bar: after");
+
+            return result;
+        }
+    }
+}

--- a/packages/ttypescript/__tests__/typescript.spec.ts
+++ b/packages/ttypescript/__tests__/typescript.spec.ts
@@ -97,4 +97,28 @@ console.log(abc.toString());
         const result = `var x = 1;\n`;
         expect(res.outputText).toEqual(result);
     });
+
+    it('should run middlewares in order', () => {
+        const lines: string[] = [];
+        const trace = (m: string) => {
+            lines.push(m);
+        }
+
+        const res = ts.transpileModule('import { itWorks } from "##arbitrary##";', {
+            compilerOptions: {
+                plugins: [
+                    { transform: __dirname + '/middlewares/create-program.ts', import: 'foo', type: 'middleware', trace },
+                    { transform: __dirname + '/middlewares/create-program.ts', import: 'bar', type: 'middleware', trace },
+                ] as any,
+            },
+        });
+
+        expect(lines).toEqual([
+            "bar: before",
+            "foo: before",
+            "in hook",
+            "foo: after",
+            "bar: after",
+        ]);
+    });
 });


### PR DESCRIPTION
This PR adds an ability to intercept arguments of `ts.createProgram` in an extensible way — with mechanism resembling Express middlewares.

By hooking methods of `ts.CompilerHost` before they are passed further, it's possible to do things I find nice:

- first class importing of non-TypeScript modules — e.g. for compiling GraphQL typedefs on the fly, or for using CSS files without bundling and import replacement.
- virtual modules — because file system access is completely incapsulated by CompilerHost, it's possible to add arbitrary resources that TypeScript compiler will see as files
- module resolution — enabling Yarn PnP without waiting for TypeScript team to agree on integration.
- etc.

I didn't include any code for implementing these scenarios, as I believe it makes more sense to keep them separated from `ttypescript`, as I assume `ts.CompilerHost` interface might change. However, it's quite trivial to implement an ad-hoc `ts.CompilerHost` delegate with desired interface using this mechanism.

I've yet exposed only `createProgram` middleware, with an intent for future expansion, as this will allow to provide composable interface to arbitrary TypeScript APIs.