### PR TITLE
Fix #134 - support TS 4.9

### DIFF
--- a/packages/ttypescript/package.json
+++ b/packages/ttypescript/package.json
@@ -4,7 +4,7 @@
     "ttsc": "./bin/tsc",
     "ttsserver": "./bin/tsserver"
   },
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "Over TypeScript tool to use custom transformers in the tsconfig.json",
   "main": "lib/typescript.js",
   "files": [

--- a/packages/ttypescript/package.json
+++ b/packages/ttypescript/package.json
@@ -4,7 +4,7 @@
     "ttsc": "./bin/tsc",
     "ttsserver": "./bin/tsserver"
   },
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "Over TypeScript tool to use custom transformers in the tsconfig.json",
   "main": "lib/typescript.js",
   "files": [

--- a/packages/ttypescript/src/tsc.ts
+++ b/packages/ttypescript/src/tsc.ts
@@ -6,9 +6,19 @@ import { runInThisContext } from 'vm';
 
 const ts = loadTypeScript('typescript', { folder: process.cwd(), forceConfigLoad: true });
 const tscFileName = resolve.sync('typescript/lib/tsc', { basedir: process.cwd() });
+const [major, minor]: [number, number] = 
+    ts.version.split(".").map(
+        (str: string) => Number(str)
+    ) as [number, number];
+
 const commandLineTsCode = fs
     .readFileSync(tscFileName, 'utf8')
-    .replace(/^[\s\S]+(\(function \(ts\) \{\s+function countLines[\s\S]+)$/, '$1');
+    .replace(
+        major >= 4 && minor >= 9
+            ? /^[\s\S]+(\(function \(ts\) {\s+var StatisticType;[\s\S]+)$/
+            : /^[\s\S]+(\(function \(ts\) \{\s+function countLines[\s\S]+)$/, 
+        '$1'
+    );
 
 const globalCode = (fs.readFileSync(tscFileName, 'utf8').match(/^([\s\S]*?)var ts;/) || ['', ''])[1];
 runInThisContext(


### PR DESCRIPTION
Just followed [`ts-patch` ](https://github.com/nonara/ts-patch/commit/26f6099543d258a2a430f8344b482aba85ac9b0e) of @nonara and it works fine in my case.

@cevek - hope `ttypescript` to support TS 4.9 ASAP.