### PR TITLE
Add deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Deprecation Notice
+
+> **`ttypescript` is deprecated**. It currently works with TS below 5.0, but it will not be updated.
+ 
+For TypeScript 5+, please use [ts-patch](https://github.com/nonara/ts-patch).
+
+---
 
 [![npm version](https://badge.fury.io/js/ttypescript.svg)](https://badge.fury.io/js/ttypescript) [![Build Status](https://travis-ci.org/cevek/ttypescript.svg?branch=master)](https://travis-ci.org/cevek/ttypescript)
 


### PR DESCRIPTION
[ts-patch](https://github.com/nonara/ts-patch) v3 is officially out and now can be swapped out for ttypescript by simply using tspc intstead of ttsc.

I know for a while, people would copy changes I made in ts-patch as PRs to keep this alive, but because we've diverged so much, this is no longer a viable option.

In order to make things easier on everyone, as I mentioned, I added an in-memory compiler, so that allows `ttypescript` users to migrate easily.

I will also be continuing to maintain it going forward, so in my view, it makes sense to add a deprecation warning here.